### PR TITLE
Rate limit fix

### DIFF
--- a/policy/auth-policy.yaml
+++ b/policy/auth-policy.yaml
@@ -18,7 +18,7 @@ spec:
             headerName: api-key
             headersFromMetadataEntry:
               x-solo-plan: 
-                name: usage-plan
+                name: usagePlan
                 required: true
 #            k8sSecretApikeyStorage:
 #              labelSelector:


### PR DESCRIPTION
**Overview**
- For rc2, we fixed an issue where rate limit wasn't working because dynamic metadata wasn't being properly emitted from the extauth server see - https://github.com/solo-io/gloo-mesh-enterprise/pull/8743
- In addition, the usagePlan metadata was not being properly captured because the current descriptor uses `usage-plan` which does not match the key specified here - https://github.com/solo-io/gloo-mesh-enterprise/blob/main/pkg/portal/apikeys/storage/storage.go#L21 we want this descriptor to be `usagePlan` instead.