### PR TITLE
Add support for IPv6 requests

### DIFF
--- a/apis/full-api/Dockerfile
+++ b/apis/full-api/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "json-server", "--host", "0.0.0.0", "--port", "5000", "db.json" ]
+CMD [ "json-server", "--host", "::", "--port", "5000", "db.json" ]

--- a/apis/pets-api/Dockerfile
+++ b/apis/pets-api/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "json-server", "--host", "0.0.0.0", "--port", "5000", "--routes", "routes.json", "db.json" ]
+CMD [ "json-server", "--host", "::", "--port", "5000", "--routes", "routes.json", "db.json" ]

--- a/apis/store-api/Dockerfile
+++ b/apis/store-api/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "json-server", "--host", "0.0.0.0", "--port", "5000", "--routes", "routes.json", "db.json" ]
+CMD [ "json-server", "--host", "::", "--port", "5000", "--routes", "routes.json", "db.json" ]

--- a/apis/tracks-api/Dockerfile
+++ b/apis/tracks-api/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "json-server", "--host", "0.0.0.0", "--port", "5000", "db.json" ]
+CMD [ "json-server", "--host", "::", "--port", "5000", "db.json" ]

--- a/apis/users-api/Dockerfile
+++ b/apis/users-api/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "json-server", "--host", "0.0.0.0", "--port", "5000", "--routes", "routes.json", "db.json" ]
+CMD [ "json-server", "--host", "::", "--port", "5000", "--routes", "routes.json", "db.json" ]


### PR DESCRIPTION
Listening to `0.0.0.0` covers all IPv4 addresses but listening to `::` covers all addresses, IPv6 and IPv4 included.

I tested this by building the `tracks-api` image locally and uploading it to a kind cluster where i run the portal-e2e test suite for gloo-mesh-enterprise.